### PR TITLE
CLS Fix for Homepage

### DIFF
--- a/src/components/sections/marqueeSection.tsx
+++ b/src/components/sections/marqueeSection.tsx
@@ -1,0 +1,66 @@
+import Marquee from "react-fast-marquee";
+
+const MarqueeSection = () => {
+    return (
+        <Marquee gradientColor={[0, 0, 0]} className={"marquee-wrapper"}>
+            <div className="slider-wrapper">
+                <img
+                    src={"/shopify.png"}
+                    width={44}
+                    height={50}
+                    alt="shopify"
+                />
+            </div>
+            <div className="slider-wrapper">
+                <img
+                    src={"/wordpress.png"}
+                    width={50}
+                    height={50}
+                    alt="wordpress"
+                />
+            </div>
+            <div className="slider-wrapper">
+                <img
+                    src={"/nextjs.png"}
+                    width={100}
+                    height={50}
+                    alt="nextjs"
+                />
+            </div>
+            <div className="slider-wrapper">
+                <img
+                    src={"/webflow.png"}
+                    width={199}
+                    height={50}
+                    alt="webflow"
+                />
+            </div>
+            <div className="slider-wrapper">
+                <img
+                    src={"/reactjs.png"}
+                    width={56}
+                    height={50}
+                    alt="reactjs"
+                />
+            </div>
+            <div className="slider-wrapper">
+                <img
+                    src={"/nodejs.png"}
+                    width={82}
+                    height={50}
+                    alt="nodejs"
+                />
+            </div>
+            <div className="slider-wrapper">
+                <img
+                    src={"/figma.png"}
+                    width={33}
+                    height={50}
+                    alt="figma"
+                />
+            </div>
+        </Marquee>
+    )
+}
+
+export default MarqueeSection;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,12 @@
 import type { NextPage } from "next";
 import FifthSection from "../components/sections/fifthSection";
 import { FourthSection } from "../components/sections/fourthSection";
-
 import HeroSection from "../components/sections/heroSection";
+import MarqueeSection from "../components/sections/marqueeSection";
 import SecondSection from "../components/sections/secondSection";
 import ServicesOffered from "../components/sections/servicesOffered";
 import pages from "../constants/pages";
 import MainLayout from "../components/layout/mainLayout";
-import Marquee from "react-fast-marquee";
-import Image from "next/image";
 import Head from "next/head";
 
 const Home: NextPage = () => {
@@ -22,71 +20,7 @@ const Home: NextPage = () => {
       </Head>
       <MainLayout pageData={pages!.home}>
         <HeroSection />
-        <Marquee gradientColor={[0, 0, 0]} className={"marquee-wrapper"}>
-          <div className="slider-wrapper">
-            <Image
-              src={"/shopify.png"}
-              width={44}
-              height={50}
-              alt="shopify"
-              layout="intrinsic"
-            />
-          </div>
-          <div className="slider-wrapper">
-            <Image
-              src={"/wordpress.png"}
-              width={50}
-              height={50}
-              alt="wordpress"
-              layout="intrinsic"
-            />
-          </div>
-          <div className="slider-wrapper">
-            <Image
-              src={"/nextjs.png"}
-              width={100}
-              height={50}
-              alt="nextjs"
-              layout="intrinsic"
-            />
-          </div>
-          <div className="slider-wrapper">
-            <Image
-              src={"/webflow.png"}
-              width={199}
-              height={50}
-              alt="webflow"
-              layout="intrinsic"
-            />
-          </div>
-          <div className="slider-wrapper">
-            <Image
-              src={"/reactjs.png"}
-              width={56}
-              height={50}
-              alt="reactjs"
-              layout="intrinsic"
-            />
-          </div>
-          <div className="slider-wrapper">
-            <Image
-              src={"/nodejs.png"}
-              width={82}
-              height={50}
-              alt="nodejs"
-              layout="intrinsic"
-            />
-          </div>
-          <div className="slider-wrapper">
-            <Image
-              src={"/figma.png"}
-              width={33}
-              height={50}
-              alt="figma"
-              layout="intrinsic"
-            />
-          </div>
-        </Marquee>
+        <MarqueeSection />
         <SecondSection />
         <ServicesOffered />
         <FourthSection />


### PR DESCRIPTION
**Issue**: CLS on Homepage for widescreens.

**Reason**: Next.js's Image component causes layout shifts

**Fix**: Next.js Image replaced with native img